### PR TITLE
Swap Blend SDK dlls for Microsoft Behaviors

### DIFF
--- a/ARK Server Manager/ARK Server Manager.csproj
+++ b/ARK Server Manager/ARK Server Manager.csproj
@@ -105,7 +105,6 @@
       <HintPath>..\packages\TaskScheduler.2.5.23\lib\net452\JetBrains.Annotations.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.Expression.Interactions, Version=4.5.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL" />
     <Reference Include="Microsoft.Win32.TaskScheduler, Version=2.5.23.0, Culture=neutral, PublicKeyToken=0d013ddd5178a2ae, processorArchitecture=MSIL">
       <HintPath>..\packages\TaskScheduler.2.5.23\lib\net452\Microsoft.Win32.TaskScheduler.dll</HintPath>
       <Private>True</Private>
@@ -117,6 +116,9 @@
     <Reference Include="Microsoft.WindowsAPICodePack.Shell, Version=1.1.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\WindowsAPICodePack-Shell.1.1.1\lib\Microsoft.WindowsAPICodePack.Shell.dll</HintPath>
       <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.Xaml.Behaviors, Version=1.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Xaml.Behaviors.Wpf.1.1.19\lib\net45\Microsoft.Xaml.Behaviors.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=10.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.10.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
@@ -138,7 +140,6 @@
       <HintPath>..\packages\Microsoft.Tpl.Dataflow.4.5.24\lib\portable-net45+win8+wpa81\System.Threading.Tasks.Dataflow.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="System.Windows.Interactivity, Version=4.5.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL" />
     <Reference Include="System.Xml" />
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Core" />
@@ -608,7 +609,7 @@
   </ItemGroup>
   <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="$(MSBuildExtensionsPath)\Microsoft\Expression\Blend\.NETFramework\v4.5\Microsoft.Expression.Blend.WPF.targets" />
+  <!--<Import Project="$(MSBuildExtensionsPath)\Microsoft\Expression\Blend\.NETFramework\v4.5\Microsoft.Expression.Blend.WPF.targets" />-->
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/ARK Server Manager/Windows/RCONWindow.xaml
+++ b/ARK Server Manager/Windows/RCONWindow.xaml
@@ -6,7 +6,7 @@
         xmlns:vm="clr-namespace:ARK_Server_Manager.Lib.ViewModel"
         xmlns:local="clr-namespace:ARK_Server_Manager"
         xmlns:sys="clr-namespace:System;assembly=mscorlib"
-        xmlns:i="clr-namespace:System.Windows.Interactivity;assembly=System.Windows.Interactivity"
+        xmlns:i="http://schemas.microsoft.com/xaml/behaviors"
         Width="1024" Height="768" ResizeMode="CanResizeWithGrip"
         SizeChanged="RCON_SizeChanged" LocationChanged="RCON_LocationChanged"
         Name="RCON" Icon="../Art/favicon.ico" Title="{Binding RCONParameters.WindowTitle}">

--- a/ARK Server Manager/Windows/RCONWindow.xaml.cs
+++ b/ARK Server Manager/Windows/RCONWindow.xaml.cs
@@ -1,6 +1,7 @@
 ﻿using ARK_Server_Manager.Lib;
 using ARK_Server_Manager.Lib.ViewModel;
 using ARK_Server_Manager.Lib.ViewModel.RCON;
+using Microsoft.Xaml.Behaviors;
 using System;
 using System.Collections.Generic;
 using System.Collections.Specialized;
@@ -13,7 +14,6 @@ using System.Windows.Controls;
 using System.Windows.Data;
 using System.Windows.Documents;
 using System.Windows.Input;
-using System.Windows.Interactivity;
 using System.Windows.Media;
 using WPFSharp.Globalizer;
 

--- a/ARK Server Manager/packages.config
+++ b/ARK Server Manager/packages.config
@@ -3,6 +3,7 @@
   <package id="DotNetZip" version="1.10.1" targetFramework="net452" />
   <package id="EO.Wpf" version="4.0.12" targetFramework="net45" />
   <package id="Microsoft.Tpl.Dataflow" version="4.5.24" targetFramework="net45" />
+  <package id="Microsoft.Xaml.Behaviors.Wpf" version="1.1.19" targetFramework="net452" />
   <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net452" />
   <package id="NLog" version="4.4.11" targetFramework="net452" />
   <package id="TaskScheduler" version="2.5.23" targetFramework="net452" />


### PR DESCRIPTION
What:
This will exchange the WPF expression blend SDK dlls like
System.Windows.Interactivity and Microsoft.Expression.Interactions
with the newer (open sourced by Microsoft) Behaviors nuget package.
It is a simple drop in replacement where you only have to change the
existing namespaces to the new package.

Why: The latest Visual Studio 2019 installers drop the Blend SDK install option
meaning you need to go out and find the Blend SDK to install from the web.
Not really a  simple task. This allows users to be able to clone, restore packages, and build
with only VS2019 installed with the correct payloads. (.Net Desktop, ASP.NET, etc)